### PR TITLE
fix: handle invalid data in rfkill

### DIFF
--- a/src/bluetooth_auto_recovery/recover.py
+++ b/src/bluetooth_auto_recovery/recover.py
@@ -23,13 +23,22 @@ def rfkill_list_bluetooth(hci: int) -> tuple[bool | None, bool | None]:
         rfkill_dict = rfkill.rfkill_list()
     except FileNotFoundError as ex:
         _LOGGER.warning(
-            "rfkill at /dev/rfkill is not accessible, cannot check bluetooth adapter: %s",
+            "rfkill at /dev/rfkill is not accessible, cannot check bluetooth adapter %s: %s",
+            hci_idx,
+            ex,
+        )
+        return None, None
+    except IndexError as ex:
+        _LOGGER.warning(
+            "rfkill at /dev/rfkill returned unexpected results, cannot check bluetooth adapter %s: %s",
+            hci_idx,
             ex,
         )
         return None, None
     except PermissionError as ex:
         _LOGGER.warning(
-            "Access to rfkill at /dev/rfkill is not permitted, cannot check bluetooth adapter: %s",
+            "Access to rfkill at /dev/rfkill is not permitted, cannot check bluetooth adapter %s: %s",
+            hci_idx,
             ex,
         )
         return None, None


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/bluetooth/scanner.py", line 360, in _async_scanner_watchdog
    await self._async_reset_adapter()
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/bluetooth/scanner.py", line 382, in _async_reset_adapter
    result = await async_reset_adapter(self.adapter)
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/bluetooth/util.py", line 79, in async_reset_adapter
    return await recover_adapter(adapter_id)
  File "/srv/homeassistant/lib/python3.10/site-packages/bluetooth_auto_recovery/recover.py", line 227, in recover_adapter
    return await _reset_bluetooth(hci)
  File "/srv/homeassistant/lib/python3.10/site-packages/bluetooth_auto_recovery/recover.py", line 130, in _reset_bluetooth
    soft_block, hard_block = await loop.run_in_executor(
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.10/site-packages/bluetooth_auto_recovery/recover.py", line 23, in rfkill_list_bluetooth
    rfkill_dict = rfkill.rfkill_list()
  File "/srv/homeassistant/lib/python3.10/site-packages/pyric/utils/rfkill.py", line 86, in rfkill_list
    soft:RFKILL_STATE[s],
IndexError: list index out of range
```