### PR TITLE
feat: reduce overhead to find a response

### DIFF
--- a/src/bluetooth_auto_recovery/recover.py
+++ b/src/bluetooth_auto_recovery/recover.py
@@ -74,8 +74,12 @@ class BluetoothMGMTProtocol(asyncio.Protocol):
 
     def data_received(self, data: bytes) -> None:
         """Handle data received."""
-        response = btmgmt_protocol.reader(data)
-        if response.cmd_response_frame and self.future and not self.future.done():
+        if (
+            self.future
+            and not self.future.done()
+            and (response := btmgmt_protocol.reader(data))
+            and response.cmd_response_frame
+        ):
             self.future.set_result(response)
 
     async def send(self, *args: Any) -> btmgmt_protocol.Response:


### PR DESCRIPTION
We now avoid parsing data when we are not waiting
for a response

When we first connect we aren't looking for a response
but if a scan is running we start drinking from the firehouse
right away.  We want to avoid decoding all those frames
until we are actually waiting for a response.

closes #16