### PR TITLE
fix: for rfkill not being readable

### DIFF
--- a/src/bluetooth_auto_recovery/recover.py
+++ b/src/bluetooth_auto_recovery/recover.py
@@ -48,6 +48,16 @@ def rfkill_list_bluetooth(hci: int) -> tuple[bool | None, bool | None]:
             ex,
         )
         return None, None
+    except UnicodeDecodeError as ex:
+        _LOGGER.debug(
+            "RF kill switch check failed - data for %s is not UTF-8 encoded: %s",
+            hci_idx,
+            ex,
+        )
+        return None, None
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception("RF kill switch check failed")
+        return None, None
     try:
         rfkill_hci_state = rfkill_dict[hci_idx]
     except KeyError:


### PR DESCRIPTION
fixes
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 372, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 309, in async_setup_entry
    await scanner.async_start()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/scanner.py", line 214, in async_start
    await self._async_start()
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/scanner.py", line 282, in _async_start
    await self._async_reset_adapter()
  File "/usr/local/lib/python3.10/site-packages/bluetooth_auto_recovery/recover.py", line 238, in recover_adapter
    soft_block, hard_block = await loop.run_in_executor(
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/site-packages/bluetooth_auto_recovery/recover.py", line 29, in rfkill_list_bluetooth
    rfkill_dict = rfkill.rfkill_list()
  File "/usr/local/lib/python3.10/site-packages/pyric/utils/rfkill.py", line 77, in rfkill_list
    stream = fin.read(rfkh.RFKILLEVENTLEN)
  File "/usr/local/lib/python3.10/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 0: invalid start byte
```