### PR TITLE
Add async before with

### DIFF
--- a/src/bluetooth_auto_recovery/recover.py
+++ b/src/bluetooth_auto_recovery/recover.py
@@ -149,7 +149,7 @@ class BluetoothMGMTProtocol(asyncio.Protocol):
         self.future = asyncio.Future()
         assert self.transport is not None  # nosec
         self.transport.write(full_pkt)
-        with async_timeout.timeout(self.timeout):
+        async with async_timeout.timeout(self.timeout):
             return await self.future
 
     def connection_lost(self, exc: Exception | None) -> None:


### PR DESCRIPTION
Fixes the deprecation warning
```
DeprecationWarning: with timeout() is deprecated, use async with timeout() instead
    with async_timeout.timeout(self.timeout):
```