### PR TITLE
fix: ensure timeouts work with py3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = "^0.18", optional = true}
 PyRIC = ">=0.1.6.3"
 btsocket = ">=0.2.0"
-async-timeout = ">=4.0.1"
+async-timeout = {version = ">=3.0.0", python = "<3.11"}
 usb-devices = ">=0.4.1"
 bluetooth-adapters = ">=0.16.0"
 

--- a/src/bluetooth_auto_recovery/util.py
+++ b/src/bluetooth_auto_recovery/util.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout  # noqa: F401
+else:
+    from asyncio import timeout as asyncio_timeout  # noqa: F401


### PR DESCRIPTION
async_timeout < 4.0.3 did not work correctly with py3.11, we now use asyncio.timeout on py3.11