### PR TITLE
fix: ensure timeout does not raise cancellation

### DIFF
--- a/src/bluetooth_auto_recovery/recover.py
+++ b/src/bluetooth_auto_recovery/recover.py
@@ -156,10 +156,9 @@ class BluetoothMGMTProtocol(asyncio.Protocol):
     async def send(self, *args: Any) -> btmgmt_protocol.Response:
         """Send command."""
         pkt_objs = btmgmt_protocol.command(*args)
-        full_pkt = b"".join(frame.octets for frame in pkt_objs if frame)
         self.future = self.loop.create_future()
         assert self.transport is not None  # nosec
-        self.transport.write(full_pkt)
+        self.transport.write(b"".join(frame.octets for frame in pkt_objs if frame))
         cancel_timeout = self.loop.call_later(
             self.timeout, self._timeout_future, self.future
         )


### PR DESCRIPTION
fixes
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 575, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 319, in async_setup_entry
    adapter = await manager.async_get_adapter_from_address_or_recover(address)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src/habluetooth/manager.py", line 240, in async_get_adapter_from_address_or_recover
  File "src/habluetooth/manager.py", line 249, in _async_recover_failed_adapters
  File "src/habluetooth/manager.py", line 256, in habluetooth.manager.BluetoothManager._async_recover_failed_adapters
  File "/usr/local/lib/python3.12/site-packages/habluetooth/util.py", line 13, in async_reset_adapter
    return await recover_adapter(adapter_id, mac_address)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/__init__.py", line 31, in recover_adapter
    return await recover_module.recover_adapter(hci, mac)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 407, in recover_adapter
    if adapter and await _power_cycle_adapter(adapter):
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 482, in _power_cycle_adapter
    return await _execute_reset(adapter)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 593, in _execute_reset
    await _execute_power_off(adapter, name, power_state_before_reset)
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 672, in _execute_power_off
    await adapter.set_powered(False)
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 288, in set_powered
    response = await self.protocol.send(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/bluetooth_auto_recovery/recover.py", line 166, in send
    return await self.future
           ^^^^^^^^^^^^^^^^^
asyncio.exceptions.CancelledError
```